### PR TITLE
Validate TLS cert from mtalk server

### DIFF
--- a/src/classes/fcm-client.ts
+++ b/src/classes/fcm-client.ts
@@ -116,7 +116,7 @@ export class FcmClient extends EventEmitter<FcmClientEvents> {
     checkin = await postAcgCheckin(this.acg.id, this.acg.securityToken)
     if (checkin instanceof Error) return checkin
 
-    this.socket = connect(MTALK_GOOGLE_PORT, MTALK_GOOGLE_HOST, { rejectUnauthorized: false, ...options })
+    this.socket = connect(MTALK_GOOGLE_PORT, MTALK_GOOGLE_HOST, options)
     this.socket.setKeepAlive(true)
 
     this.socket.on('close', this.onSocketClose)


### PR DESCRIPTION
TLS certificates are not validated when connecting to mtalk. Is there a reason for this? If not then it would be good to remove this because it opens up the possibility of a MiTM to intercept and trigger messages. 

If this is for testing or something like that then it would be good to pass it in as an option on the constructor instead.